### PR TITLE
Update package.json to not assume globally installed 'typings' package

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "phantomjs-prebuilt": "^2.1.3",
     "tslint": "^3.3.0",
     "typescript": "^1.8.0",
-    "webpack": "^1.12.12"
+    "webpack": "^1.12.12",
+    "typings": "^2.1.1"
   },
   "engines": {
     "npm": "2.7.4"


### PR DESCRIPTION
Package.json should include the typings library, since it should not assume globally installed packages.